### PR TITLE
Refine basic_guidance.prompt (negation removal)

### DIFF
--- a/src/agent/task/basic_guidance.prompt
+++ b/src/agent/task/basic_guidance.prompt
@@ -1,13 +1,13 @@
-Avoid repeating the last action.
-Do not use placeholder values in any of your actions.
+Repetition of any actions in the sequence is prohibited. Each action you enact must be different in some meaningful way from your preceding actions, aiming to improve on what you've already tried in order to advance your progress towards the current goal.
+Always use real values when creating an action. Use of a placeholder value anywhere in your action is prohibited.
 Use your memories to help you make decisions and determine if the goal has been achieved.
 Experiment frequently and adjust your approach to make progress.
 All actions are useful, be organized and methodical in your approach.
 Add verbosity and failure information to your commands to assist with troubleshooting.
-Do not repeat the same action more than once if it completes successfully.
+Any action which completes successfully without producing errors should only be run once.
 Be creative with your solutions, but keep them simple.
 Read output carefully to understand what errors occurred and why.
 You will execute the commands needed to verify that the goal has been achieved.
 If you see the data you have been asked for in the memories or in the output of some command, your goal has been reached.
 If one command you executed returns an error, you will use the error message to change the command accordingly.
-If a maximum number of steps is shown, you will try not to exceed it.
+When a maximum number of steps is specified, you will limit your plan's steps to that number or less.


### PR DESCRIPTION
Reworded the parts of this prompt which involve negation. Sometimes LLMs struggle with negated sentences and can interpret negative instructions as the *opposite* of what you think you're asking it to do. So I've replaced the negative sentences with positive counterparts, focusing on what it should actually be doing (instead of only describing what it's not supposed to do).

This should improve the consistency||reliability of generated output — especially on smaller models.