### PR TITLE
Add pagination support for output

### DIFF
--- a/nerve/cli/run.py
+++ b/nerve/cli/run.py
@@ -75,12 +75,14 @@ async def _run(extra_args: list[str], args: Arguments) -> None:
             max_cost=args.max_cost,
             timeout=args.timeout,
             start_state=start_state,
+            paginate=args.paginate,
+            max_output=args.max_output,
         )
 
     elif Configuration.is_agent_config(args.input_path):
         # single agent
         flow = await Flow.build(
-            actors=[await Agent.create_from_file(args.generator, args.input_path, args.conversation_strategy)],
+            actors=[await Agent.create_from_file(args.generator, args.input_path, args.conversation_strategy, paginate=args.paginate, max_output=args.max_output)],
             max_steps=args.max_steps,
             max_cost=args.max_cost,
             timeout=args.timeout,

--- a/nerve/cli/serve.py
+++ b/nerve/cli/serve.py
@@ -121,6 +121,8 @@ async def _serve(
             name=agent_name,
             configuration=config,
             debug=run_args.debug,
+            paginate=run_args.paginate,
+            max_output=run_args.max_output,
         )
 
     if mcp or mcp_sse:

--- a/nerve/cli/utils.py
+++ b/nerve/cli/utils.py
@@ -105,6 +105,14 @@ def _get_run_args(
         str,
         typer.Option("--start-state", help="Pass the initial input state as a JSON string."),
     ] = "{}",
+    paginate: t.Annotated[
+        bool,
+        typer.Option("--paginate", help="Enable pagination of tool output."),
+    ] = False,
+    max_output: t.Annotated[
+        int,
+        typer.Option("--max-output", help="Maximum output size for tool pagination."),
+    ] = 4096,
 ) -> Arguments:
     return Arguments(
         input_path=_resolve_input_path(input_path),
@@ -125,4 +133,6 @@ def _get_run_args(
         trace=trace,
         # parse the start_state JSON string into a dictionary
         start_state=json.loads(start_state),
+        paginate=paginate,
+        max_output=max_output,
     )

--- a/nerve/models.py
+++ b/nerve/models.py
@@ -124,6 +124,7 @@ class Configuration(BaseModel):
         max_steps: int | None = None
         max_cost: float | None = None
         timeout: int | None = None
+        max_output: int = 4096
 
     # legacy field used to detect if the user is loading a legacy file
     system_prompt: str | None = Field(default=None, exclude=True)

--- a/nerve/runtime/agent.py
+++ b/nerve/runtime/agent.py
@@ -41,6 +41,8 @@ class Agent:
         window_strategy: WindowStrategy = FullHistoryStrategy(),
         working_dir: pathlib.Path = pathlib.Path.cwd(),
         name: str = "agent",
+        paginate: bool = False,
+        max_output: int = 4096,
     ) -> "Agent":
         """
         Create an agent from a generator and configuration.
@@ -52,6 +54,8 @@ class Agent:
             window_strategy: How to handle conversation history.
             working_dir: The working directory to use.
             name: The name of the agent.
+            paginate: Enable pagination of tool output.
+            max_output: Maximum output size for tool pagination.
         """
 
         if start_state:
@@ -75,6 +79,8 @@ class Agent:
             working_dir=working_dir,
             name=name,
             configuration=configuration,
+            paginate=paginate,
+            max_output=max_output,
         )
 
         return cls(
@@ -91,6 +97,8 @@ class Agent:
         config_file_path: pathlib.Path,
         window_strategy: WindowStrategy = FullHistoryStrategy(),
         start_state: dict[str, str] | None = None,
+        paginate: bool = False,
+        max_output: int = 4096,
     ) -> "Agent":
         config = Configuration.from_path(config_file_path)
         if config.is_legacy:
@@ -106,6 +114,8 @@ class Agent:
             window_strategy,
             working_dir,
             stem if stem not in ("task", "agent") else working_dir.stem,
+            paginate=paginate,
+            max_output=max_output,
         )
 
     def _get_system_prompt(self) -> str | None:

--- a/nerve/runtime/flow.py
+++ b/nerve/runtime/flow.py
@@ -72,6 +72,8 @@ class Flow:
         max_cost: float = 10.0,
         timeout: int | None = None,
         start_state: dict[str, str] | None = None,
+        paginate: bool = False,
+        max_output: int = 4096,
     ) -> "Flow":
         workflow = Workflow.from_path(input_path)
         root_path = input_path if input_path.is_dir() else input_path.parent
@@ -83,7 +85,7 @@ class Flow:
             if not task_file_path.exists():
                 task_file_path = root_path / actor_name
 
-            actors.append(await Agent.create_from_file(actor.generator, task_file_path, window_strategy))
+            actors.append(await Agent.create_from_file(actor.generator, task_file_path, window_strategy, paginate=paginate, max_output=max_output))
 
         if start_state:
             state.update_variables(start_state)

--- a/nerve/runtime/runner.py
+++ b/nerve/runtime/runner.py
@@ -31,6 +31,8 @@ class Arguments(BaseModel):
     log_path: pathlib.Path | None
     trace: pathlib.Path | None
     start_state: dict[str, t.Any]
+    paginate: bool = False
+    max_output: int = 4096
 
     def to_serializable(self) -> dict[str, t.Any]:
         return {
@@ -63,6 +65,13 @@ def _create_command_line(
     if run_args.timeout:
         command_line.append("--timeout")
         command_line.append(str(run_args.timeout))
+
+    if run_args.paginate:
+        command_line.append("--paginate")
+
+    if run_args.max_output:
+        command_line.append("--max-output")
+        command_line.append(str(run_args.max_output))
 
     # if run_args.quiet:
     #     command_line.append("--quiet")

--- a/nerve/tools/body.j2
+++ b/nerve/tools/body.j2
@@ -13,7 +13,12 @@ from nerve.tools.namespaces.shell import shell
 {% set func_ret_type = "None" %}
 {% endif %}
 
-def {{ tool.name }}({% for arg in tool.arguments %}{{ arg.name }}: Annotated[str, Field(description="""{{ arg.description }}""", examples=["""{{ arg.example }}"""])]{% if not loop.last %}, {% endif %}{% endfor %}) -> {{ func_ret_type }}:
+def {{ tool.name }}(
+    {%- for arg in tool.arguments %}
+        {{ arg.name }}: Annotated[str, Field(description="""{{ arg.description }}""", examples=["""{{ arg.example }}"""])]{% if not loop.last or paginate %}, {% endif %}
+    {%- endfor %}
+    {%- if paginate %}page: Annotated[int, Field(description="Page number for paginated output. Optional.")] = 1{% endif %}
+) -> {{ func_ret_type }}:
     """{{ tool.description }}"""
 
 {% if tool.tool is none %}

--- a/nerve/tools/compiler.py
+++ b/nerve/tools/compiler.py
@@ -17,11 +17,11 @@ from nerve.models import Tool
 from nerve.runtime import state
 
 
-def wrap_tool_function(func: t.Callable[..., t.Any], mime: str | None = None) -> t.Callable[..., t.Any]:
+def wrap_tool_function(func: t.Callable[..., t.Any], mime: str | None = None, paginate: bool = False, max_output: int = 4096) -> t.Callable[..., t.Any]:
     """
     Creates a wrapper around a function that logs the function call and its result.
+    If paginate is True, truncates output with a hint if needed.
     """
-
     async def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
         logger.debug(f"calling {func.__name__} ...")
 
@@ -30,8 +30,20 @@ def wrap_tool_function(func: t.Callable[..., t.Any], mime: str | None = None) ->
         started_at = time.time()
         error = None
         try:
+            # Get page as string first, convert to integer
+            page_str = kwargs.get('page', '1') if paginate else '1'
+            try:
+                page = int(page_str)
+            except (ValueError, TypeError):
+                return f"[Error: Invalid page number: {page_str}. Page must be an integer.]"
+
+            # Ensure page is at least 1
+            if page < 1:
+                 # Decide whether to default to 1 or return an error
+                 # For now, let's return an error as per requirement 8
+                 return f"[Error: Page number must be a positive integer. Requested page was {page_str}.]"
+
             result = func(*args, **kwargs)
-            # check if the tool function returned a coroutine
             if asyncio.iscoroutine(result):
                 result = await result
 
@@ -56,16 +68,42 @@ def wrap_tool_function(func: t.Callable[..., t.Any], mime: str | None = None) ->
             else:
                 logger.error(f"tool {func.__name__} references an unsupported mime type: {mime}")
                 exit(1)
+        # Pagination logic
+        elif paginate and isinstance(result, str):
+            content_bytes = result.encode('utf-8')
+            total_size = len(content_bytes)
+            page_size = max_output
+            total_pages = (total_size + page_size - 1) // page_size
 
+            # Check page again after calculating total_pages for out-of-range error
+            if page > total_pages and total_pages > 0: # Only check upper bound if there's at least one page
+                 return f"[Error: Requested page {page} is out of range. There are {total_pages} pages.]"
+
+            start = (page - 1) * page_size
+            end = min(start + page_size, total_size)
+            page_bytes = content_bytes[start:end]
+            try:
+                page_content = page_bytes.decode('utf-8')
+            except UnicodeDecodeError:
+                for i in range(len(page_bytes) - 1, -1, -1):
+                    try:
+                        page_content = page_bytes[:i].decode('utf-8')
+                        break
+                    except UnicodeDecodeError:
+                        continue
+                else:
+                    page_content = ''
+            if total_size > max_output:
+                hint = f"[Output truncated. Use the optional 'page' parameter to fetch more. This is page {page} of {total_pages} ({total_size} bytes total).]"
+                return page_content + '\n' + hint
+            else:
+                return page_content
         return result
-
-    # Preserve the function's metadata
     wrapper = functools.wraps(func)(wrapper)
-
     return wrapper
 
 
-def get_tools_from_namespace(namespace: str, jail: list[str]) -> list[t.Callable[..., t.Any]]:
+def get_tools_from_namespace(namespace: str, jail: list[str], paginate: bool = False, max_output: int = 4096) -> list[t.Callable[..., t.Any]]:
     try:
         importlib.util.find_spec(f"nerve.tools.namespaces.{namespace}")
     except ImportError as err:
@@ -79,7 +117,7 @@ def get_tools_from_namespace(namespace: str, jail: list[str]) -> list[t.Callable
                 logger.debug(f"namespace {namespace} jailed to: {jailed_path}")
 
         module_tools = [
-            wrap_tool_function(func)
+            wrap_tool_function(func, paginate=paginate, max_output=max_output)
             for (name, func) in inspect.getmembers(module, inspect.isfunction)
             if name[0] != "_" and func.__module__ == module.__name__
         ]
@@ -92,16 +130,18 @@ def get_tools_from_namespace(namespace: str, jail: list[str]) -> list[t.Callable
 def get_tools_from_namespaces(
     namespaces: list[str],
     jail: dict[str, list[str]],
+    paginate: bool = False,
+    max_output: int = 4096,
 ) -> list[t.Callable[..., t.Any]]:
     tools = []
 
     for namespace in namespaces:
-        tools.extend(get_tools_from_namespace(namespace, jail.get(namespace, [])))
+        tools.extend(get_tools_from_namespace(namespace, jail.get(namespace, []), paginate=paginate, max_output=max_output))
 
     return tools
 
 
-def get_tools_from_file(working_dir: pathlib.Path, file: str) -> list[t.Callable[..., t.Any]]:
+def get_tools_from_file(working_dir: pathlib.Path, file: str, paginate: bool = False, max_output: int = 4096) -> list[t.Callable[..., t.Any]]:
     tool_path = pathlib.Path(file)
     if not tool_path.is_absolute():
         tool_path = working_dir / tool_path
@@ -116,7 +156,7 @@ def get_tools_from_file(working_dir: pathlib.Path, file: str) -> list[t.Callable
     spec.loader.exec_module(module)  # type: ignore
 
     module_tools = [
-        wrap_tool_function(func)
+        wrap_tool_function(func, paginate=paginate, max_output=max_output)
         for (name, func) in inspect.getmembers(module, inspect.isfunction)
         if name[0] != "_" and func.__module__ == module.__name__
     ]
@@ -127,23 +167,25 @@ def get_tools_from_file(working_dir: pathlib.Path, file: str) -> list[t.Callable
     return module_tools
 
 
-def get_tools_from_files(working_dir: pathlib.Path, files: list[str]) -> list[t.Callable[..., t.Any]]:
+def get_tools_from_files(working_dir: pathlib.Path, files: list[str], paginate: bool = False, max_output: int = 4096) -> list[t.Callable[..., t.Any]]:
     tools = []
 
     for file in files:
-        tools.extend(get_tools_from_file(working_dir, file))
+        tools.extend(get_tools_from_file(working_dir, file, paginate=paginate, max_output=max_output))
 
     return tools
 
 
-def get_tool_from_yml(working_dir: pathlib.Path, tool: Tool) -> t.Callable[..., t.Any]:
+def get_tool_from_yml(working_dir: pathlib.Path, tool: Tool, paginate: bool = False, max_output: int = 4096) -> t.Callable[..., t.Any]:
     # load the template from the same directory as this script
     template_path = os.path.join(os.path.dirname(__file__), "body.j2")
     with open(template_path) as f:
         template_content = f.read()
 
+    logger.debug(f"get_tool_from_yml: tool={tool.name}, paginate={paginate}, max_output={max_output}")
+
     func_body = (
-        jinja2.Environment().from_string(template_content).render(tool=tool, working_dir=str(working_dir.absolute()))
+        jinja2.Environment().from_string(template_content).render(tool=tool, working_dir=str(working_dir.absolute()), paginate=paginate)
     )
 
     logger.debug(f"compiling tool {tool.name} as:\n{func_body}")
@@ -151,14 +193,14 @@ def get_tool_from_yml(working_dir: pathlib.Path, tool: Tool) -> t.Callable[..., 
     func_namespace: dict[str, t.Any] = {}
     exec(func_body, func_namespace)
 
-    return wrap_tool_function(func_namespace[tool.name], tool.mime)
+    return wrap_tool_function(func_namespace[tool.name], tool.mime, paginate=paginate, max_output=max_output)
 
 
-def get_tools_from_yml(working_dir: pathlib.Path, yml_tools: list[Tool]) -> list[t.Callable[..., t.Any]]:
+def get_tools_from_yml(working_dir: pathlib.Path, yml_tools: list[Tool], paginate: bool = False, max_output: int = 4096) -> list[t.Callable[..., t.Any]]:
     tools = []
 
     for tool in yml_tools:
-        tools.append(get_tool_from_yml(working_dir, tool))
+        tools.append(get_tool_from_yml(working_dir, tool, paginate=paginate, max_output=max_output))
 
     if tools:
         logger.debug(f"importing {len(tools)} tools from {working_dir}")


### PR DESCRIPTION
In some cases, it's useful to limit long tool output*. This feature adds pagination support.

It adds two command line parameters to `run` and `serve`, `--paginate` and `--max-output`. Using `--paginate` will enable the feature. `--max-output` is set to 4096 by default.

Enabling paginate will have an optional `page` parameter added to all tool functions. It will also truncate the output to `max-output` size, and provide hints back to the LLM that there are other pages.

Since the `page` parameter is optional, if the tool is run as normal with `paginate` enabled then the output will only be truncated if it exceeds `max-output` otherwise it will behave as normal with no change.

The change is made by injecting the optional `page` parameter via the jinja template. The rest of the code is mostly making sure that the command line option is propagated all the way down to the templating. I'm a little uncertain that I did this is the right way, and would be open to direction if there's a better way.

* I've found two specific use cases for limiting output:

1) Claude Desktop implements three separate limits for tool response (1M), message size (10k characters) and a varying conversation length.

2) Reducing input tokens for cost purposes.

Often hints from the first few pages are enough for very long tool output e.g. to get the LLM to generate more targeted searches for the content it needs. Or knowing the content is at the end of a long output, the last page could be grabbed without the rest of the output.