### PR TITLE
Fix: default value argument in jinja template causing errors

### DIFF
--- a/nerve/tools/mcp/body.j2
+++ b/nerve/tools/mcp/body.j2
@@ -2,7 +2,7 @@ from typing import *
 from pydantic import Field
 from loguru import logger
 
-async def {{ tool.name }}({% for arg in arguments %}{{ arg.name }}: Annotated[{{ arg.type }}, "{{ arg.description }}"]{% if 'default' in arg %} = {{ arg.default }}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> Any:
+async def {{ tool.name }}({% for arg in arguments %}{{ arg.name }}: Annotated[{{ arg.type }}, "{{ arg.description }}"]{% if 'default' in arg %} = {% if arg.type == "str" %}"{{ arg.default }}"{% else %}{{ arg.default >
     """{{ tool.description }}"""
 
     return await globals().get("{{ client_name }}", None).call_tool("{{ tool.name }}", **locals())

--- a/nerve/tools/mcp/body.j2
+++ b/nerve/tools/mcp/body.j2
@@ -2,7 +2,7 @@ from typing import *
 from pydantic import Field
 from loguru import logger
 
-async def {{ tool.name }}({% for arg in arguments %}{{ arg.name }}: Annotated[{{ arg.type }}, "{{ arg.description }}"]{% if 'default' in arg %} = {% if arg.type == "str" %}"{{ arg.default }}"{% else %}{{ arg.default >
+async def {{ tool.name }}({% for arg in arguments %}{{ arg.name }}: Annotated[{{ arg.type }}, "{{ arg.description }}"]{% if 'default' in arg %} = {% if arg.type == "str" %}"{{ arg.default }}"{% else %}{{ arg.default }}{% endif %}{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}) -> Any:
     """{{ tool.description }}"""
 
     return await globals().get("{{ client_name }}", None).call_tool("{{ tool.name }}", **locals())


### PR DESCRIPTION
When the jinja template (body.j2) is used to render the functions made available by the MCP server, there is a default value argument which is referenced in the template.

When this argument is a boolean or int, everything is fine. But for string args which have a default value, the quotes don't get added around the value leading to a NameError.

To reproduce:
- Just follow the instructions here, substituting nerve in place of Claude Desktop: https://docs.browser-use.com/customize/mcp-server